### PR TITLE
[#19]feat:공공서비스 제안글 상세보기 기능 구현

### DIFF
--- a/client/src/api/getBoardDetail.ts
+++ b/client/src/api/getBoardDetail.ts
@@ -1,0 +1,11 @@
+import { firebaseApp } from "../config/firebase";
+import { getFirestore, doc, getDoc } from "firebase/firestore";
+
+const db = getFirestore(firebaseApp);
+
+export const getBoardDetail = async (boardID: string) => {
+  const docRef = doc(db, "board", boardID);
+  const docSnap = await getDoc(docRef);
+
+  return docSnap.data();
+};


### PR DESCRIPTION
### 📌 제목
공공서비스 제안글 상세보기 기능 구현

### 📌 변경 내용
공공서비스 제안글 상세보기 기능을 구현했습니다.

### 📌 참고 및 관련 이슈 번호 참고해야할 팀원
함수 호출 이후 .then()을 사용하여 데이터를 받아와야 합니다.

### 📌 기타 사항
```tsx
export const getBoardDetail = async (boardID: string) => {
  const docRef = doc(db, "board", boardID);
  const docSnap = await getDoc(docRef);

  return docSnap.data();
};
```
