### PR TITLE
[#21]feat:공공서비스 제안글 삭제 기능 구현

### DIFF
--- a/client/src/api/deleteBoard.ts
+++ b/client/src/api/deleteBoard.ts
@@ -1,0 +1,18 @@
+import { firebaseApp } from "../config/firebase";
+import { getFirestore, doc, getDoc, deleteDoc } from "firebase/firestore";
+import { store } from "../redux/store";
+
+const db = getFirestore(firebaseApp);
+
+export const deleteBoard = async (boardID: string) => {
+  const docRef = doc(db, "board", boardID);
+  const docSnap = await getDoc(docRef);
+  let user = store.getState().authStore.uid;
+  let data: any = docSnap.data();
+
+  if (user === data.user) {
+    await deleteDoc(docRef);
+  } else {
+    alert("삭제 권한이 없습니다.");
+  }
+};


### PR DESCRIPTION
### 📌 제목
공공서비스 제안글 삭제 기능 구현

### 📌 변경 내용
공공서비스 제안글 삭제 기능을 구현했습니다. 

### 📌 참고 및 관련 이슈 번호 참고해야할 팀원

### 📌 기타 사항
```tsx
export const deleteBoard = async (boardID: string) => {
  const docRef = doc(db, "board", boardID);
  const docSnap = await getDoc(docRef);
  let user = store.getState().authStore.uid;
  let data: any = docSnap.data();

  if (user === data.user) {
    await deleteDoc(docRef);
  } else {
    alert("삭제 권한이 없습니다.");
  }
};
```
